### PR TITLE
Add proper alpha masking to AOImage elements

### DIFF
--- a/src/aoimage.cpp
+++ b/src/aoimage.cpp
@@ -2,6 +2,8 @@
 
 #include "aoimage.h"
 
+#include <QBitmap>
+
 AOImage::AOImage(QWidget *parent, AOApplication *p_ao_app) : QLabel(parent)
 {
   m_parent = parent;
@@ -29,9 +31,9 @@ bool AOImage::set_image(QString p_image)
   }
 
   QPixmap f_pixmap(final_image_path);
-
-  this->setPixmap(
-      f_pixmap.scaled(this->width(), this->height(), Qt::IgnoreAspectRatio));
+  f_pixmap = f_pixmap.scaled(this->width(), this->height(), Qt::IgnoreAspectRatio);
+  this->setPixmap(f_pixmap);
+  this->setMask(f_pixmap.mask());
   return true;
 }
 
@@ -44,8 +46,9 @@ bool AOImage::set_chatbox(QString p_path)
   }
 
   QPixmap f_pixmap(p_path);
+  f_pixmap = f_pixmap.scaled(this->width(), this->height(), Qt::IgnoreAspectRatio);
 
-  this->setPixmap(
-      f_pixmap.scaled(this->width(), this->height(), Qt::IgnoreAspectRatio));
+  this->setPixmap(f_pixmap);
+  this->setMask(f_pixmap.mask());
   return true;
 }


### PR DESCRIPTION
This should fix issues in themes that attempt to use irregular layouts (or even things like putting the evidence button in a cutout of the evidence menu)